### PR TITLE
Expand the image generation response

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A TypeScript SDK for Ablo Services",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/interfaces/image-generation-response.interface.ts
+++ b/src/interfaces/image-generation-response.interface.ts
@@ -1,6 +1,7 @@
-import { IAbloImage } from './ablo-image.interface'
+import { IAbloImage } from "./ablo-image.interface";
 
 export interface IImageGenerationResponse {
-  images: IAbloImage[]
-  riskScore?: number
+  images: IAbloImage[];
+  riskScore?: number;
+  creditsRemaining?: number;
 }

--- a/src/interfaces/single-image-generation-response.interface.ts
+++ b/src/interfaces/single-image-generation-response.interface.ts
@@ -1,6 +1,7 @@
-import { IAbloImage } from './ablo-image.interface'
+import { IAbloImage } from "./ablo-image.interface";
 
 export interface ISingleImageGenerationResponse {
-  image: IAbloImage
-  riskScore?: number
+  image: IAbloImage;
+  riskScore?: number;
+  creditsRemaining?: number;
 }


### PR DESCRIPTION
### Description (what's changed?)

Expands the image generation response type with credits remaining. This new version has already been published and is used in the dashboard to update the credits pill in the sidebar after every credits consuming action.
