### PR TITLE
Add optional cache control config to storage upload function

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "A TypeScript SDK for Ablo Services",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/services/storage/index.ts
+++ b/src/services/storage/index.ts
@@ -1,30 +1,32 @@
-import { AxiosInstance } from 'axios'
+import { AxiosHeaders, AxiosInstance } from 'axios'
 
 export class StorageService {
-  constructor(private readonly axios: AxiosInstance) {}
+  constructor(private readonly axios: AxiosInstance) { }
 
   /**
    * Uploads an image from a base64 string to the storage service.
    * @param image - The base64 encoded image.
    * @param contentType - The content type of the image.
+   * @param options - Optional parameters for the upload, such as cache control.
    * @returns A Promise that resolves to the URL of the uploaded image.
    */
-  uploadBase64 = async (image: string, contentType: string): Promise<string> => {
+  uploadBase64 = async (image: string, contentType: string, options?: { cacheControl?: string }): Promise<string> => {
     const url = await this.getSignedUrl(contentType)
     const blob = await fetch(image).then((res) => res.blob())
-    return this.upload(url, blob as unknown as string, contentType)
+    return this.upload(url, blob as unknown as string, contentType, options)
   }
 
   /**
    * Uploads an image to the storage service.
    * @param image - The image to be uploaded.
    * @param contentType - The content type of the image.
+   * @param options - Optional parameters for the upload, such as cache control.
    * @returns A Promise that resolves to the URL of the uploaded image.
    */
-  uploadBlob = async (image: File | ArrayBuffer | string, contentType: string): Promise<string> => {
+  uploadBlob = async (image: File | ArrayBuffer | string, contentType: string, options?: { cacheControl?: string }): Promise<string> => {
     const url = await this.getSignedUrl(contentType)
 
-    return this.upload(url, image, contentType)
+    return this.upload(url, image, contentType, options)
   }
 
   /**
@@ -42,16 +44,22 @@ export class StorageService {
    * @param url - The URL to upload the image to.
    * @param image - The image to be uploaded.
    * @param contentType - The content type of the image.
+   * @param options - Optional parameters for the upload, such as cache control.
    * @returns A Promise that resolves to the URL of the uploaded image.
    */
   upload = async (
     url: string,
     image: File | ArrayBuffer | string,
-    contentType: string
+    contentType: string,
+    options?: { cacheControl?: string }
   ): Promise<string> => {
-    await this.axios.put(url, image, {
-      headers: { 'Content-Type': contentType },
-    })
+    const headers = new AxiosHeaders()
+    headers.append('Content-Type', contentType)
+    if (options?.cacheControl) {
+      headers.append('Cache-Control', options.cacheControl)
+    }
+
+    await this.axios.put(url, image, { headers: headers })
     return url.split('?')[0]
   }
 }


### PR DESCRIPTION
### Description (what's changed?)
New `Cache-Control` header added to Storage upload function. this way we can achieve having 1 year cache duration instead of default one hour. It is optional because we should only use this for manufacturingImageUrls images.
